### PR TITLE
gcc-cross: fix the build failure with GCC6

### DIFF
--- a/meta/recipes-devtools/gcc/gcc-5.2.inc
+++ b/meta/recipes-devtools/gcc/gcc-5.2.inc
@@ -74,6 +74,7 @@ SRC_URI = "\
            file://0040-nativesdk-gcc-support.patch \
            file://0041-handle-target-sysroot-multilib.patch \
            file://0042-cxxflags-for-build.patch \
+           file://0043-cfns-fix-mismatch-in-gnu_inline-attributes.patch \
           "
 
 BACKPORTS = ""

--- a/meta/recipes-devtools/gcc/gcc-5.2/0043-cfns-fix-mismatch-in-gnu_inline-attributes.patch
+++ b/meta/recipes-devtools/gcc/gcc-5.2/0043-cfns-fix-mismatch-in-gnu_inline-attributes.patch
@@ -1,0 +1,28 @@
+diff --git a/gcc/cp/cfns.gperf b/gcc/cp/cfns.gperf
+index 68acd3d..953262f 100644
+--- a/gcc/cp/cfns.gperf
++++ b/gcc/cp/cfns.gperf
+@@ -22,6 +22,9 @@ __inline
+ static unsigned int hash (const char *, unsigned int);
+ #ifdef __GNUC__
+ __inline
++#ifdef __GNUC_STDC_INLINE__
++__attribute__ ((__gnu_inline__))
++#endif
+ #endif
+ const char * libc_name_p (const char *, unsigned int);
+ %}
+diff --git a/gcc/cp/cfns.h b/gcc/cp/cfns.h
+index 1c6665d..6d00c0e 100644
+--- a/gcc/cp/cfns.h
++++ b/gcc/cp/cfns.h
+@@ -53,6 +53,9 @@ __inline
+ static unsigned int hash (const char *, unsigned int);
+ #ifdef __GNUC__
+ __inline
++#ifdef __GNUC_STDC_INLINE__
++__attribute__ ((__gnu_inline__))
++#endif
+ #endif
+ const char * libc_name_p (const char *, unsigned int);
+ /* maximum key range = 391, duplicates = 0 */


### PR DESCRIPTION
The patch is ported from http://patchwork.ozlabs.org/patch/504982/,
resolving the following build failure:

gcc-5.2.0/gcc/cp/except.c:1023:0:
cfns.gperf: In function 'const char* libc_name_p(const char*, unsigned
int)':
cfns.gperf:101:1: error: 'const char* libc_name_p(const char*, unsigned
int)' redeclared inline with 'gnu_inline' attribute
cfns.gperf:26:14: note: 'const char* libc_name_p(const char*, unsigned
int)' previously declared here
cfns.gperf: At global scope:
cfns.gperf:26:14: warning: inline function 'const char*
libc_name_p(const char*, unsigned int)' used but never defined
Makefile:1066: recipe for target 'cp/except.o' failed

Because gcc has lots of variants, we have to integrate this patch to
oe-core instead of wrlabs-integration.

Signed-off-by: Lans Zhang <jia.zhang@windriver.com>