### PR TITLE
oe-core fix bundle

### DIFF
--- a/meta/classes/kernel.bbclass
+++ b/meta/classes/kernel.bbclass
@@ -238,6 +238,7 @@ do_bundle_initramfs () {
 		done
 	fi
 }
+do_bundle_initramfs[dirs] = "${B}"
 
 python do_devshell_prepend () {
     os.environ["LDFLAGS"] = ''

--- a/meta/classes/package.bbclass
+++ b/meta/classes/package.bbclass
@@ -819,6 +819,9 @@ python split_and_strip_files () {
     dvar = d.getVar('PKGD', True)
     pn = d.getVar('PN', True)
 
+    oldcwd = os.getcwd()
+    os.chdir(dvar)
+
     # We default to '.debug' style
     if d.getVar('PACKAGE_DEBUG_SPLIT_STYLE', True) == 'debug-file-directory':
         # Single debug-file-directory style debug info
@@ -841,8 +844,6 @@ python split_and_strip_files () {
 
     sourcefile = d.expand("${WORKDIR}/debugsources.list")
     bb.utils.remove(sourcefile)
-
-    os.chdir(dvar)
 
     # Return type (bits):
     # 0 - not elf
@@ -1029,6 +1030,7 @@ python split_and_strip_files () {
     #
     # End of strip
     #
+    os.chdir(oldcwd)
 }
 
 python populate_packages () {
@@ -2145,4 +2147,3 @@ def mapping_rename_hook(d):
     runtime_mapping_rename("RDEPENDS", pkg, d)
     runtime_mapping_rename("RRECOMMENDS", pkg, d)
     runtime_mapping_rename("RSUGGESTS", pkg, d)
-


### PR DESCRIPTION
Both fixes ported from upstream resolve the issues caused by the bitbake commit 67a7b8b02 "build: don't use $B as the default cwd for functions" (included in current bitbake master).