### PR TITLE
qt4-native fix bundle

### DIFF
--- a/meta/recipes-qt/qt4/qt4-4.8.7.inc
+++ b/meta/recipes-qt/qt4/qt4-4.8.7.inc
@@ -26,6 +26,7 @@ SRC_URI = "http://download.qt-project.org/official_releases/qt/4.8/${PV}/qt-ever
            file://0032-aarch64_add_header.patch \
            file://0034-Fix-kmap2qmap-build-with-clang.patch \
            file://0036-qt-everywhere-opensource-src-4.8.7-gcc6.patch \
+           file://gcc-6.patch \
            file://Fix-QWSLock-invalid-argument-logs.patch \
            file://add_check_for_aarch64_32.patch \
            file://g++.conf \

--- a/meta/recipes-qt/qt4/qt4-4.8.7.inc
+++ b/meta/recipes-qt/qt4/qt4-4.8.7.inc
@@ -25,6 +25,7 @@ SRC_URI = "http://download.qt-project.org/official_releases/qt/4.8/${PV}/qt-ever
            file://0031-aarch64_arm64_mkspecs.patch \
            file://0032-aarch64_add_header.patch \
            file://0034-Fix-kmap2qmap-build-with-clang.patch \
+           file://0036-qt-everywhere-opensource-src-4.8.7-gcc6.patch \
            file://Fix-QWSLock-invalid-argument-logs.patch \
            file://add_check_for_aarch64_32.patch \
            file://g++.conf \
@@ -36,6 +37,9 @@ SRC_URI[md5sum] = "d990ee66bf7ab0c785589776f35ba6ad"
 SRC_URI[sha256sum] = "e2882295097e47fe089f8ac741a95fef47e0a73a3f3cdf21b56990638f626ea0"
 
 S = "${WORKDIR}/qt-everywhere-opensource-src-${PV}"
+
+# workaround for class std::auto_ptr' is deprecated with gcc-6
+CXXFLAGS += "-std=gnu++98 -Wno-deprecated"
 
 # disable webkit for mips64 n32 temporarily that fails to compile,
 # qt upstream defect:

--- a/meta/recipes-qt/qt4/qt4-4.8.7/0036-qt-everywhere-opensource-src-4.8.7-gcc6.patch
+++ b/meta/recipes-qt/qt4/qt4-4.8.7/0036-qt-everywhere-opensource-src-4.8.7-gcc6.patch
@@ -1,0 +1,24 @@
+Avoid implicit conversions, which are now flagged by gcc6
+
+| api/qcoloroutput_p.h:74:60: error: shift expression '(1048575 << 20)' overflows [-fpermissive]
+| api/qcoloroutput_p.h:74:63: error: enumerator value for 'BackgroundMask' is not an integer constant
+|              BackgroundMask  = ((1 << BackgroundShift) - 1) << BackgroundShift
+
+
+Upstream-Status: Inappropriate [Frozen upstream]
+Signed-off-by: Khem Raj <raj.khem@gmail.com>
+
+diff -up qt-everywhere-opensource-src-4.8.7/src/xmlpatterns/api/qcoloroutput_p.h.than qt-everywhere-opensource-src-4.8.7/src/xmlpatterns/api/qcoloroutput_p.h
+--- qt-everywhere-opensource-src-4.8.7/src/xmlpatterns/api/qcoloroutput_p.h.than	2016-02-03 11:43:04.567757448 +0100
++++ qt-everywhere-opensource-src-4.8.7/src/xmlpatterns/api/qcoloroutput_p.h	2016-02-04 13:12:26.394350271 +0100
+@@ -70,8 +70,8 @@ namespace QPatternist
+             ForegroundShift = 10,
+             BackgroundShift = 20,
+             SpecialShift    = 20,
+-            ForegroundMask  = ((1 << ForegroundShift) - 1) << ForegroundShift,
+-            BackgroundMask  = ((1 << BackgroundShift) - 1) << BackgroundShift
++            ForegroundMask  = 0x1f << ForegroundShift,
++            BackgroundMask  = 0x7 << BackgroundShift
+         };
+ 
+     public:

--- a/meta/recipes-qt/qt4/qt4-4.8.7/gcc-6.patch
+++ b/meta/recipes-qt/qt4/qt4-4.8.7/gcc-6.patch
@@ -1,0 +1,19 @@
+Allow gcc v6 to build webkit. Without this, webkit isn't built
+when gcc v6 is used (silently but then python-pyqt fails to build).
+
+Upstream-Status: Inappropriate [no development on qt4 now]
+RP 2016/5/26
+
+Index: qt-everywhere-opensource-src-4.8.7/configure
+===================================================================
+--- qt-everywhere-opensource-src-4.8.7.orig/configure
++++ qt-everywhere-opensource-src-4.8.7/configure
+@@ -7756,7 +7756,7 @@ case "$XPLATFORM" in
+     *-g++*)
+ 	# Check gcc's version
+ 	case "$(${QMAKE_CONF_COMPILER} -dumpversion)" in
+-	    5*|4*|3.4*)
++	    6*|5*|4*|3.4*)
+ 		;;
+             3.3*)
+                 canBuildWebKit="no"

--- a/meta/recipes-qt/qt4/qt4-native.inc
+++ b/meta/recipes-qt/qt4/qt4-native.inc
@@ -16,10 +16,15 @@ SRC_URI = "http://download.qt-project.org/official_releases/qt/4.8/${PV}/qt-ever
            file://0002-qkbdtty_qws-fix-build-with-old-kernel-headers.patch \
            file://0003-webkit2-set-OUTPUT_DIR-value-if-empty.patch \
            file://0021-configure-make-qt4-native-work-with-long-building-pa.patch \
+	   file://0036-qt-everywhere-opensource-src-4.8.7-gcc6.patch \
+	   file://gcc-6.patch \
            file://g++.conf \
            file://linux.conf \
 	"
 S = "${WORKDIR}/qt-everywhere-opensource-src-${PV}"
+
+# workaround for class std::auto_ptr' is deprecated with gcc-6
+CXXFLAGS += "-std=gnu++98 -Wno-deprecated"
 
 EXTRA_OECONF = "-prefix ${prefix} \
                 -bindir ${bindir} \


### PR DESCRIPTION
These patches are ported from meta-qt4 upstream, resolving the following build failure:

parser -Ischema -Itype -Iutils -I.moc/release-shared-emb-x86_64 -o .obj/release-shared-emb-x86[540/2844]
elocation.o api/qsourcelocation.cpp
| In file included from api/qcoloringmessagehandler_p.h:57:0,
|                  from api/qxmlquery_p.h:67,
|                  from api/qpullbridge.cpp:48:
| api/qcoloroutput_p.h:74:60: warning: result of '(1048575 << 20)' requires 41 bits to represent, but 'i
nt' only has 32 bits [-Wshift-overflow=]
|              BackgroundMask  = ((1 << BackgroundShift) - 1) << BackgroundShift
|                                ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~^~~~~~~~~~~~~~~~~~
| api/qcoloroutput_p.h:74:60: error: shift expression '(1048575 << 20)' overflows [-fpermissive]
| api/qcoloroutput_p.h:74:63: error: enumerator value for 'BackgroundMask' is not an integer constant
|              BackgroundMask  = ((1 << BackgroundShift) - 1) << BackgroundShift
|                                                                ^~~~~~~~~~~~~~~
| Makefile:2834: recipe for target '.obj/release-shared-emb-x86_64/qvariableloader.o' failed
| make: *** [.obj/release-shared-emb-x86_64/qvariableloader.o] Error 1
| make: *** Waiting for unfinished jobs....
| Makefile:4192: recipe for target '.obj/release-shared-emb-x86_64/qpullbridge.o' failed
| make: *** [.obj/release-shared-emb-x86_64/qpullbridge.o] Error 1
| ERROR: oe_runmake failed
| ERROR: Function failed: do_compile (log file is located at /home/jzhang0/Workspace/pulsar/pulsar-8/wr-
core/build-intel-apollolake/tmp/work/x86_64-linux/qt4-native/4.8.7-r0/temp/log.do_compile.21023)
ERROR: Task 6 (/home/jzhang0/Workspace/pulsar/pulsar-8/wr-core/layers/oe-core/meta/recipes-qt/qt4/qt4-na
tive_4.8.7.bb, do_compile) failed with exit code '1'