### PR TITLE
rpm signing fix bundle

### DIFF
--- a/meta/classes/sign_package_feed.bbclass
+++ b/meta/classes/sign_package_feed.bbclass
@@ -28,4 +28,4 @@ python () {
                                    'PACKAGE-FEED-GPG-PUBKEY'))
 }
 
-do_package_index[depends] += "signing-keys:do_export_public_keys"
+do_package_index[depends] += "signing-keys-native:do_export_public_keys"

--- a/meta/classes/sign_rpm.bbclass
+++ b/meta/classes/sign_rpm.bbclass
@@ -77,5 +77,5 @@ python sign_rpm () {
         raise bb.build.FuncFailed("RPM signing failed")
 }
 
-do_package_index[depends] += "signing-keys:do_export_public_keys"
-sign_rpm[depends] += "signing-keys:do_export_public_keys"
+do_package_index[depends] += "signing-keys-native:do_export_public_keys"
+sign_rpm[depends] += "signing-keys-native:do_export_public_keys"

--- a/meta/recipes-core/meta/signing-keys.bb
+++ b/meta/recipes-core/meta/signing-keys.bb
@@ -43,3 +43,5 @@ python do_export_public_keys () {
                           d.getVar('PACKAGE_FEED_GPG_PUBKEY', True))
 }
 addtask do_export_public_keys before do_build after do_populate_sysroot
+
+BBCLASSEXTEND="native"

--- a/meta/recipes-core/os-release/os-release.bb
+++ b/meta/recipes-core/os-release/os-release.bb
@@ -37,7 +37,7 @@ python do_compile () {
         shutil.copy2(rpm_gpg_pubkey, d.expand('${B}/rpm-gpg/RPM-GPG-KEY-%s' % distro_version))
 }
 do_compile[vardeps] += "${OS_RELEASE_FIELDS}"
-do_compile[depends] += "signing-keys:do_export_public_keys"
+do_compile[depends] += "signing-keys-native:do_export_public_keys"
 
 do_install () {
     install -d ${D}${sysconfdir}


### PR DESCRIPTION
signing-key itself is only used for importing/exporting pubkey on build
host, so it is not required to build it for target.

Signed-off-by: Lans Zhang <jia.zhang@windriver.com>