### PR TITLE
signing-keys: support to use gpg2 to export pubkey

### DIFF
--- a/meta/recipes-core/meta/signing-keys.bb
+++ b/meta/recipes-core/meta/signing-keys.bb
@@ -23,6 +23,7 @@ EXCLUDE_FROM_WORLD = "1"
 def export_gpg_pubkey(d, keyid, path):
     import bb
     gpg_bin = d.getVar('GPG_BIN', True) or \
+              bb.utils.which(os.getenv('PATH'), "gpg2") or \
               bb.utils.which(os.getenv('PATH'), "gpg")
     cmd = '%s --batch --yes --export --armor -o %s %s' % \
           (gpg_bin, path, keyid)


### PR DESCRIPTION
According to the rule of using gpg/gpg2, gpg2 is always preferred.

Signed-off-by: Lans Zhang <jia.zhang@windriver.com>