### PR TITLE
sign_rpm: enable gpg home directory support

### DIFF
--- a/meta/classes/sign_rpm.bbclass
+++ b/meta/classes/sign_rpm.bbclass
@@ -24,6 +24,10 @@ python () {
     # Set the expected location of the public key
     d.setVar('RPM_GPG_PUBKEY', os.path.join(d.getVar('STAGING_ETCDIR_NATIVE'),
                                             'RPM-GPG-PUBKEY'))
+
+    # Set default GPG_PATH if it is not configured
+    if not d.getVar('GPG_PATH', True):
+        d.setVar('GPG_PATH', d.getVar('DEPLOY_DIR_IMAGE', True) + '/.gnupg')
 }
 
 

--- a/meta/classes/sign_rpm.bbclass
+++ b/meta/classes/sign_rpm.bbclass
@@ -32,7 +32,11 @@ python () {
 
 
 def rpmsign_wrapper(d, files, passphrase, gpg_name=None):
-    import pexpect
+    try:
+        import pexpect
+    except:
+        raise bb.build.FuncFailed("RPM signing failed. No python-pexpect. " + \
+                "Please apt-get install python-pexpect or yum install python pexpect")
 
     # Find the correct rpm binary
     rpm_bin_path = d.getVar('STAGING_BINDIR_NATIVE', True) + '/rpm'

--- a/meta/recipes-core/meta/signing-keys.bb
+++ b/meta/recipes-core/meta/signing-keys.bb
@@ -25,8 +25,8 @@ def export_gpg_pubkey(d, keyid, path):
     gpg_bin = d.getVar('GPG_BIN', True) or \
               bb.utils.which(os.getenv('PATH'), "gpg2") or \
               bb.utils.which(os.getenv('PATH'), "gpg")
-    cmd = '%s --batch --yes --export --armor -o %s %s' % \
-          (gpg_bin, path, keyid)
+    cmd = '%s --homedir %s --batch --yes --export --armor -o %s %s' % \
+          (gpg_bin, d.getVar('GPG_PATH', True), path, keyid)
     status, output = oe.utils.getstatusoutput(cmd)
     if status:
         raise bb.build.FuncFailed('Failed to export gpg public key (%s): %s' %


### PR DESCRIPTION
This is to avoid contaminate build host's keyring, if GPG_PATH is not
configured, a default path will be given.

Signed-off-by: Yunguo Wei <yunguo.wei@windriver.com>