### PR TITLE
sign_rpm: adding dependency

### DIFF
--- a/meta/classes/sign_rpm.bbclass
+++ b/meta/classes/sign_rpm.bbclass
@@ -91,4 +91,4 @@ python sign_rpm () {
 }
 
 do_package_index[depends] += "signing-keys-native:do_export_public_keys"
-sign_rpm[depends] += "signing-keys-native:do_export_public_keys"
+do_package_write_rpm[depends] += "signing-keys-native:do_export_public_keys"


### PR DESCRIPTION
We should define dependency based on task rather than function.

Signed-off-by: Yunguo Wei <yunguo.wei@windriver.com>