### PR TITLE
gnupg: fix a native dependency issue

### DIFF
--- a/meta/recipes-support/gnupg/gnupg_1.4.7.bb
+++ b/meta/recipes-support/gnupg/gnupg_1.4.7.bb
@@ -1,6 +1,7 @@
 SUMMARY = "GNU Privacy Guard - encryption and signing tools"
 HOMEPAGE = "http://www.gnupg.org/"
 DEPENDS = "zlib bzip2 readline"
+DEPENDS_class-native = "zlib-native bzip2-replacement-native readline-native"
 SECTION = "console/utils"
 
 LICENSE = "GPLv2"


### PR DESCRIPTION
bzip2 supplies bzip2-native via "bzip2-replacement-native", without this
patch gnupg-native is configured as NOT support bzip2, and that is not
what we expect.

Signed-off-by: Yunguo Wei <yunguo.wei@windriver.com>