### PR TITLE
boost: Replace math::static_lcm with integer

### DIFF
--- a/meta/recipes-support/boost/boost/boost-CVE-2012-2677.patch
+++ b/meta/recipes-support/boost/boost/boost-CVE-2012-2677.patch
@@ -26,7 +26,7 @@ index c47b11f..417a1e0 100644
 +    size_type max_chunks() const
 +    { //! Calculated maximum number of memory chunks that can be allocated in a single call by this Pool.
 +      size_type partition_size = alloc_size();
-+      size_type POD_size = math::static_lcm<sizeof(size_type), sizeof(void *)>::value + sizeof(size_type);
++      size_type POD_size = integer::static_lcm<sizeof(size_type), sizeof(void *)>::value + sizeof(size_type);
 +      size_type max_chunks = (std::numeric_limits<size_type>::max() - POD_size) / alloc_size(); 
 +
 +      return max_chunks;


### PR DESCRIPTION
Replace math with integer according to the commit upstream:

(From OE-Core rev: 2e2ecd867d47ee24b37f61af6db5338df5059844)

Signed-off-by: Ross Burton <ross.burton@intel.com>
Signed-off-by: Richard Purdie <richard.purdie@linuxfoundation.org>