### PR TITLE
dnf/librepo: encrypt/decrypt password of remote rpm repository uri

### DIFF
--- a/meta/recipes-devtools/dnf/dnf/0001-do-not-quote-password-proxy_password.patch
+++ b/meta/recipes-devtools/dnf/dnf/0001-do-not-quote-password-proxy_password.patch
@@ -1,0 +1,28 @@
+From 1073b690cb4effd2539b6a76df4c56b61ebd0856 Mon Sep 17 00:00:00 2001
+From: Hongxu Jia <hongxu.jia@windriver.com>
+Date: Mon, 11 Jun 2018 23:37:09 +0800
+Subject: [PATCH] do not quote password/proxy_password
+
+Upstream-Status: Inappropriate [pulsar specific]
+
+Signed-off-by: Hongxu Jia <hongxu.jia@windriver.com>
+---
+ dnf/repo.py | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/dnf/repo.py b/dnf/repo.py
+index c897566..46d4ea7 100644
+--- a/dnf/repo.py
++++ b/dnf/repo.py
+@@ -81,7 +81,7 @@ def _user_pass_str(user, password):
+     if user is None:
+         return None
+     user = dnf.pycomp.urllib_quote(user)
+-    password = '' if password is None else dnf.pycomp.urllib_quote(password)
++    password = '' if password is None else password
+     return '%s:%s' % (user, password)
+ 
+ 
+-- 
+2.7.4
+

--- a/meta/recipes-devtools/dnf/dnf_2.6.3.bb
+++ b/meta/recipes-devtools/dnf/dnf_2.6.3.bb
@@ -11,6 +11,7 @@ SRC_URI = "git://github.com/rpm-software-management/dnf.git \
            file://0001-Do-not-hardcode-etc-and-systemd-unit-directories.patch \
            file://0001-Corretly-install-tmpfiles.d-configuration.patch \
            file://0001-Check-conf.releasever-instead-of-releasever.patch \
+           file://0001-do-not-quote-password-proxy_password.patch \
            "
 
 SRCREV = "be2585183ec4485ee4d5e121f242d8669296f065"

--- a/meta/recipes-devtools/librepo/librepo/0001-decrypt-password.patch
+++ b/meta/recipes-devtools/librepo/librepo/0001-decrypt-password.patch
@@ -1,0 +1,110 @@
+From 4a6b6c0e1b4465ada1ad0593e8c8fbcfcfb40c72 Mon Sep 17 00:00:00 2001
+From: Hongxu Jia <hongxu.jia@windriver.com>
+Date: Mon, 11 Jun 2018 21:52:10 +0800
+Subject: [PATCH] decrypt password
+
+Invoke openssl cli to decrypt password
+
+Upstream-Status: Inappropriate [pulsar specific]
+
+Signed-off-by: Hongxu Jia <hongxu.jia@windriver.com>
+---
+ librepo/handle.c | 74 +++++++++++++++++++++++++++++++++++++++++++++++++++++---
+ 1 file changed, 71 insertions(+), 3 deletions(-)
+
+diff --git a/librepo/handle.c b/librepo/handle.c
+index ff39db4..43e4016 100644
+--- a/librepo/handle.c
++++ b/librepo/handle.c
+@@ -234,6 +234,69 @@ lr_handle_remote_sources_changed(LrHandle *handle, LrChangedRemoteSource type)
+     }
+ }
+ 
++static int invoke_program(const char*cmd, char *out, int out_len)
++{
++    FILE *fp;
++
++#ifdef DEBUG
++    printf("CMD: %s\n", cmd);
++#endif
++    if ((fp = popen(cmd, "r")) == NULL)
++    {
++        printf("Error opening pipe!\n");
++        return -1;
++    }
++
++    while (fgets(out, out_len, fp) != NULL)
++    {
++#ifdef DEBUG
++        printf("OUTPUT: %s", out);
++#endif
++
++        // Strip newline
++        char *pos;
++        if ((pos=strchr(out, '\n')) != NULL)
++           *pos = '\0';
++    }
++
++    if(pclose(fp))
++    {
++#ifdef DEBUG
++        printf("Command not found or exited with error status\n");
++#endif
++        return -1;
++    }
++
++    return 0;
++}
++
++
++static gboolean
++decrypt_password (char *userpass, char *userpass_decrypt)
++{
++    char *username = strtok(userpass, ":");
++    if (username == NULL)
++        return FALSE;
++
++    char *encrypt_password = strtok(NULL, "");
++    if (encrypt_password == NULL)
++        return FALSE;
++
++    char cmd[1024];
++    char out[1024];
++    sprintf(cmd, "echo %s | openssl enc -d -aes-256-cbc -md md5 -base64 -salt -pass pass:%s 2>/dev/null",
++                  encrypt_password, "incendia");
++    if (invoke_program(cmd, out, sizeof(out)))
++        return FALSE;
++
++    sprintf(userpass_decrypt, "%s:%s", username, out);
++
++#ifdef DEBUG
++    printf("%s %d, %s -> %s\n", __FUNCTION__, __LINE__, userpass, userpass_decrypt);
++#endif
++  return TRUE;
++}
++
+ gboolean
+ lr_handle_setopt(LrHandle *handle,
+                  GError **err,
+@@ -319,10 +382,15 @@ lr_handle_setopt(LrHandle *handle,
+         }
+         break;
+ 
+-    case LRO_USERPWD:
+-        c_rc = curl_easy_setopt(c_h, CURLOPT_USERPWD, va_arg(arg, char *));
+-        break;
++    case LRO_USERPWD: {
++        char *userpass = va_arg(arg, char *);
++        char userpass_decrypt[1024];
+ 
++        strcpy(userpass_decrypt, userpass);
++        decrypt_password (userpass, userpass_decrypt);
++        c_rc = curl_easy_setopt(c_h, CURLOPT_USERPWD, userpass_decrypt);
++        break;
++    }
+     case LRO_PROXY:
+         c_rc = curl_easy_setopt(c_h, CURLOPT_PROXY, va_arg(arg, char *));
+         break;
+-- 
+2.7.4
+

--- a/meta/recipes-devtools/librepo/librepo_git.bb
+++ b/meta/recipes-devtools/librepo/librepo_git.bb
@@ -8,6 +8,7 @@ SRC_URI = "git://github.com/rpm-software-management/librepo.git \
            file://0003-tests-fix-a-race-when-deleting-temporary-directories.patch \
            file://0004-Set-gpgme-variables-with-pkg-config-not-with-cmake-m.patch \
            file://0005-Fix-typo-correct-LRO_SSLVERIFYHOST-with-CURLOPT_SSL_.patch \
+           file://0001-decrypt-password.patch \
            "
 
 PV = "1.7.20+git${SRCPV}"
@@ -16,6 +17,7 @@ SRCREV = "e1137cbbda78fecb192146300790680a5bc811b1"
 S = "${WORKDIR}/git"
 
 DEPENDS = "curl expat glib-2.0 openssl attr libcheck gpgme"
+RDEPENDS_${PN} += "openssl"
 
 inherit cmake distutils3-base pkgconfig
 


### PR DESCRIPTION
username: user1
password: 123456

1. Encrypt password
$ echo 123456 | openssl enc -e -aes-256-cbc -md md5 -base64 -salt -pass pass:incendia
U2FsdGVkX18LDq7XDpv+AYRyIEW9RmzM6o1SSz0xQFY=

2. Create repo conf with encrypt password on target
mkdir /etc/yum.repos.d/
cat > /etc/yum.repos.d/pulsar-linux.repo << END
[pulsar-linux]
name=pulsar-linux
baseurl=http://128.224.156.107/rpm
enabled=1
username=user1
password=U2FsdGVkX18LDq7XDpv+AYRyIEW9RmzM6o1SSz0xQFY=
END

3. invoking `dnf -v makecache' works well

4. Create repo conf with plain password on target
mkdir /etc/yum.repos.d/
cat > /etc/yum.repos.d/pulsar-linux.repo << END
[pulsar-linux]
name=pulsar-linux
baseurl=http://128.224.156.107/rpm
enabled=1
username=user1
password=123456
END

5. invoking `dnf -v makecache' works well

Signed-off-by: Hongxu Jia <hongxu.jia@windriver.com>